### PR TITLE
 Fix description for profile types on register

### DIFF
--- a/views/default/profile_manager/register/fields.php
+++ b/views/default/profile_manager/register/fields.php
@@ -50,7 +50,7 @@
 			}
 			
 			// Generate type descriptions for all profile types
-			$type_description = "";
+			$types_description = "";
 			foreach($types as $type){
 				$types_options_values[$type->guid] = $type->getTitle();
 				


### PR DESCRIPTION
Because the $type_description loop define a fresh $type_description with every iteration, only the last description is displayed. Simple fix by using a string accumulator. 
