### PR TITLE
Check ignore access when checking for admin only fields

### DIFF
--- a/classes/ColdTrick/ProfileManager/ProfileFields.php
+++ b/classes/ColdTrick/ProfileManager/ProfileFields.php
@@ -60,7 +60,7 @@ class ProfileFields {
 
 		// make new result
 		foreach ($ordered_entities as $entity) {
-			if ($entity->admin_only != 'yes' || elgg_is_admin_logged_in()) {
+			if ($entity->admin_only != 'yes' || (elgg_is_admin_logged_in() || elgg_get_ignore_access())) {
 
 				$result[$entity->metadata_name] = $entity->metadata_type;
 
@@ -136,7 +136,7 @@ class ProfileFields {
 	
 		// Order the group fields and filter some types out
 		foreach ($entities as $group_field) {
-			if ($group_field->admin_only != 'yes' || elgg_is_admin_logged_in()) {
+			if ($group_field->admin_only != 'yes' || (elgg_is_admin_logged_in() || elgg_get_ignore_access())) {
 				$ordered[$group_field->order] = $group_field;
 			}
 		}


### PR DESCRIPTION
This fixes some issues for plugins when they're using set_ignore_access to get all metadata. Now only the normal user data was set (not the admin_only) since ignore_access isn't being checked.